### PR TITLE
Add configuration and tests to make the module Debian-compatible

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class zookeeper (
   if !is_integer($myid) { fail('The $myid parameter must be an integer number') }
   validate_string($package_name)
   validate_string($package_ensure)
+  validate_string($package_origin)
   if !is_integer($peer_port) { fail('The $peer_port parameter must be an integer number') }
   validate_array($quorum)
   validate_bool($service_autorestart)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class zookeeper (
   $myid                   = $zookeeper::params::myid,
   $package_name           = $zookeeper::params::package_name,
   $package_ensure         = $zookeeper::params::package_ensure,
+  $package_origin         = $zookeeper::params::package_origin,
   $peer_port              = $zookeeper::params::peer_port,
   $quorum                 = $zookeeper::params::quorum,
   $service_autorestart    = hiera('zookeeper::service_autorestart', $zookeeper::params::service_autorestart),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class zookeeper::params {
   $myid                   = 1
   $package_name           = 'zookeeper-server'
   $package_ensure         = 'present'
+  $package_origin         = 'Cloudera'
   $peer_port              = 2888
   # If you want to use a quorum (normally 3 or 5 members), set this variable to e.g.
   # ['server.1=zookeeper1:2888:3888', 'server.2=zookeeper2:2888:3888', ...] where # server.<X> corresponds to a
@@ -44,6 +45,7 @@ class zookeeper::params {
                                         # your RPM uses a different user
   case $::osfamily {
     'RedHat': {}
+    'Debian': {}
 
     default: {
       fail("The ${module_name} module is not supported on a ${::osfamily} based system.")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,7 +19,7 @@ class zookeeper::service inherits zookeeper {
       }
     }
     else {
-      $initialize_check = 'false'
+      $initialize_check = false
     }
 
     exec { 'zookeeper-initialize':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,13 +12,18 @@ class zookeeper::service inherits zookeeper {
 
   if $service_manage == true {
 
-    $initialize_check = $is_standalone ? {
-      true  => "test ! -d ${data_dir}/version-2",
-      false => "test ! -d ${data_dir}/version-2 -o ! -s ${data_dir}/myid",
-    }
+    if $package_origin != 'Cloudera' {
+	    $initialize_check = $is_standalone ? {
+	      true  => "test ! -d ${data_dir}/version-2",
+	      false => "test ! -d ${data_dir}/version-2 -o ! -s ${data_dir}/myid",
+	    }
+	  }
+	  else {
+	    $initialize_check = ''
+	  }
 
     exec { 'zookeeper-initialize':
-      command => 'service zookeeper-server init',
+      command => "service ${package_name} init",
       path    => ['/usr/bin', '/usr/sbin', '/sbin', '/bin'],
       user    => 'root',
       onlyif  => $initialize_check,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,7 @@ class zookeeper::service inherits zookeeper {
 
   if $service_manage == true {
 
-    if $package_origin != 'Cloudera' {
+    if $package_origin == 'Cloudera' {
       $initialize_check = $is_standalone ? {
         true  => "test ! -d ${data_dir}/version-2",
         false => "test ! -d ${data_dir}/version-2 -o ! -s ${data_dir}/myid",

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,14 +13,14 @@ class zookeeper::service inherits zookeeper {
   if $service_manage == true {
 
     if $package_origin != 'Cloudera' {
-	    $initialize_check = $is_standalone ? {
-	      true  => "test ! -d ${data_dir}/version-2",
-	      false => "test ! -d ${data_dir}/version-2 -o ! -s ${data_dir}/myid",
-	    }
-	  }
-	  else {
-	    $initialize_check = ''
-	  }
+      $initialize_check = $is_standalone ? {
+        true  => "test ! -d ${data_dir}/version-2",
+        false => "test ! -d ${data_dir}/version-2 -o ! -s ${data_dir}/myid",
+      }
+    }
+    else {
+      $initialize_check = ''
+    }
 
     exec { 'zookeeper-initialize':
       command => "service ${package_name} init",

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -19,7 +19,7 @@ class zookeeper::service inherits zookeeper {
       }
     }
     else {
-      $initialize_check = ''
+      $initialize_check = 'false'
     }
 
     exec { 'zookeeper-initialize':

--- a/spec/classes/zookeeper_service_spec.rb
+++ b/spec/classes/zookeeper_service_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'zookeeper::service' do
   context 'supported operating systems' do
-    ['RedHat'].each do |osfamily|
-      ['RedHat', 'CentOS', 'Amazon', 'Fedora'].each do |operatingsystem|
+    ['RedHat', 'Debian'].each do |osfamily|
+      ['RedHat', 'CentOS', 'Amazon', 'Fedora', 'Ubuntu', 'Debian'].each do |operatingsystem|
         let(:facts) {{
           :osfamily        => osfamily,
           :operatingsystem => operatingsystem,

--- a/spec/classes/zookeeper_spec.rb
+++ b/spec/classes/zookeeper_spec.rb
@@ -118,7 +118,7 @@ describe 'zookeeper' do
             'command' => 'service zookeeper-server init',
             'path'    => ['/usr/bin', '/usr/sbin', '/sbin', '/bin'],
             'user'    => 'root',
-            'onlyif'  => '',
+            'onlyif'  => 'false',
             'require' => [ 'Class[Zookeeper::Install]', 'Class[Zookeeper::Config]' ],
           })}
         end

--- a/spec/classes/zookeeper_spec.rb
+++ b/spec/classes/zookeeper_spec.rb
@@ -118,7 +118,7 @@ describe 'zookeeper' do
             'command' => 'service zookeeper-server init',
             'path'    => ['/usr/bin', '/usr/sbin', '/sbin', '/bin'],
             'user'    => 'root',
-            'onlyif'  => 'false',
+            'onlyif'  => false,
             'require' => [ 'Class[Zookeeper::Install]', 'Class[Zookeeper::Config]' ],
           })}
         end


### PR DESCRIPTION
I don't think it would be too hard to make this Debian-compatible.

Creating a .deb from a .rpm is trivial with tools like [alien](https://help.ubuntu.com/community/RPM/AlienHowto). Also, the Cloudera repo has .deb packages, but this module seems too coupled with the Cloudera package.

If you download the zookeeper tar.gz from the apache project page, you can untar it and build a deb or rpm package from the source using ant. But the control scripts in these packages are different than what the Cloudera package provides. Mainly, they don't require a 'service zookeeper-server init'.

I'm adding a parameter to indicate if the package comes from Cloudera or somewhere else, with a default of Cloudera. Then I use that to construct the $initialize_check variable and setting it to empty if the service doesn't need to be initialized.

Accordingly I'm also adding 'Debian' to the list of supported os families.

One last minor thing: I'm parameterizing the 'zookeeper-initialize' exec to sync it up with the $package_name variable.

I'm much less familiar with zookeeper than with puppet, so it's possible that I'm overseeing something, but I'd appreciate the feedback so I can rework my solution.

Thanks!
